### PR TITLE
Use composite key for SnapNutrient posts

### DIFF
--- a/app/api/social_media/comment/route.ts
+++ b/app/api/social_media/comment/route.ts
@@ -22,20 +22,20 @@ export async function POST(req: Request) {
             text
         });
 
-        if (!postId || !text) {
-            return NextResponse.json({ error: "Post ID and text are required" }, { status: 400 });
+        if (!postId || !photo_id || !text) {
+            return NextResponse.json({ error: "Post ID, photo_id and text are required" }, { status: 400 });
         }
 
         const user = session.user.email;
         
         try {
-            // Add the comment using just the postId
+            // Add the comment using the primary key
             const updatedPost = await addComment(postId, photo_id, user, text);
             console.log("Comment added successfully");
             
             // Get the full updated post to return
             try {
-                const fullPost = await getPostById(postId);
+                const fullPost = await getPostById(postId, photo_id);
                 if (fullPost) {
                     return NextResponse.json({ 
                         success: true, 

--- a/app/api/social_media/like/route.ts
+++ b/app/api/social_media/like/route.ts
@@ -18,8 +18,8 @@ export async function POST(req: Request) {
         const data = await req.json();
         const { postId, photo_id} = data;
 
-        if (!postId) {
-            return NextResponse.json({ error: "Post ID is required" }, { status: 400 });
+        if (!postId || !photo_id) {
+            return NextResponse.json({ error: "Post ID and photo_id are required" }, { status: 400 });
         }
 
         console.log("Processing like for post:", postId);
@@ -41,7 +41,7 @@ export async function POST(req: Request) {
 
         // Fallback if Attributes aren't returned - try to get the post
         try {
-            const updatedPost = await getPostById(postId);
+            const updatedPost = await getPostById(postId, photo_id);
             return NextResponse.json({ 
                 success: true, 
                 data: updatedPost

--- a/app/api/social_media/route.ts
+++ b/app/api/social_media/route.ts
@@ -155,13 +155,14 @@ export async function GET(req: Request) {
 // export async function GET_BY_ID(req: Request) {
 //     const { searchParams } = new URL(req.url);
 //     const postId = searchParams.get('id');
+//     const photoId = searchParams.get('photo_id');
 
-//     if (!postId) {
-//         return NextResponse.json({ error: 'Post ID is required' }, { status: 400 });
+//     if (!postId || !photoId) {
+//         return NextResponse.json({ error: 'Post ID and photo_id are required' }, { status: 400 });
 //     }
 
 //     try {
-//         const post = await getPostById(postId);
+//         const post = await getPostById(postId, photoId);
 //         if (!post) {
 //             return NextResponse.json({ error: 'Post not found' }, { status: 404 });
 //         }
@@ -176,13 +177,14 @@ export async function GET(req: Request) {
 // export async function DELETE(req: Request) {
 //     const { searchParams } = new URL(req.url);
 //     const postId = searchParams.get('id');
+//     const photoId = searchParams.get('photo_id');
 
-//     if (!postId) {
-//         return NextResponse.json({ error: 'Post ID is required' }, { status: 400 });
+//     if (!postId || !photoId) {
+//         return NextResponse.json({ error: 'Post ID and photo_id are required' }, { status: 400 });
 //     }
 
 //     try {
-//         await deletePost(postId);
+//         await deletePost(postId, photoId);
 //         return NextResponse.json({ success: true, message: 'Post deleted successfully' });
 //     } catch (error) {
 //         console.error('Error in DELETE /api/social-media:', error);


### PR DESCRIPTION
## Summary
- require `photo_id` sort key for post operations
- update like/comment API routes to provide `photo_id`
- document composite key usage in sample routes

## Testing
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c19a03d3d88330823d5ef0d1e77c7d