### PR TITLE
feat: toggle post likes per user

### DIFF
--- a/app/api/social_media/like/route.ts
+++ b/app/api/social_media/like/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
         console.log("Processing like for post:", postId);
 
         // Call the likePost function to update the like count
-        const result = await likePost(postId, photo_id);
+        const result = await likePost(postId, photo_id, session.user.email);
         console.log("Like operation result:", result);
 
         // If successful, return the updated post data

--- a/app/api/social_media/route.ts
+++ b/app/api/social_media/route.ts
@@ -4,12 +4,13 @@ import { authOptions } from "@/app/api/auth/[...nextauth]/route";
 import { addPost, getLatestPosts} from "@/lib/socialPostFunctions"
 
 interface SocialMediaTable{
-    id: string; 
-    photo_id: string; 
-    caption: string; 
+    id: string;
+    photo_id: string;
+    caption: string;
     comments: { user: string; text: string }[];
     likes: number;
-    posted_time: string;  
+    liked_by: string[];
+    posted_time: string;
 }
 
 //validate if social post follows format
@@ -47,6 +48,7 @@ export async function POST(req: Request) {
             caption: post.caption,
             comments: post.comments || [],
             likes: post.likes ? parseInt(post.likes, 10) : 0,
+            liked_by: [],
             posted_time: timestamp
         };
         


### PR DESCRIPTION
## Summary
- track which users like a post and toggle likes on repeat actions
- expose user email to like endpoint and initialize liked-by field when saving posts
- render posts with liked state and support unlike from the UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a38510cc83309a478f0f273619e8