### PR TITLE
fix: avoid empty liked_by attribute

### DIFF
--- a/lib/socialPostFunctions.ts
+++ b/lib/socialPostFunctions.ts
@@ -27,13 +27,17 @@ export async function addPost(post: SocialMediaPost) {
     TableName: SOCIAL_MEDIA_TABLE,
     Item: {
       id: { S: post.id },
-      photo_id: { S: post.photo_id},
+      photo_id: { S: post.photo_id },
       caption: { S: post.caption },
       likes: { N: post.likes.toString() },
-      liked_by: { SS: post.liked_by || [] },
-      comments: { L: post.comments.map(comment => ({
-        M: { user: { S: comment.user }, text: { S: comment.text } }
-      })) },
+      ...(post.liked_by && post.liked_by.length > 0
+        ? { liked_by: { SS: post.liked_by } }
+        : {}),
+      comments: {
+        L: post.comments.map(comment => ({
+          M: { user: { S: comment.user }, text: { S: comment.text } }
+        }))
+      },
       posted_time: { S: post.posted_time || now },
       feed_type: { S: "GLOBAL" }
     },


### PR DESCRIPTION
## Summary
- omit `liked_by` attribute when no users like post to prevent DynamoDB validation errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a88ada9c8330a11fc2c8e781b695