### PR TITLE
Normalize analysis result structure

### DIFF
--- a/app/api/openai/analyze-image/route.ts
+++ b/app/api/openai/analyze-image/route.ts
@@ -51,7 +51,27 @@ export async function POST(req: Request) {
                 throw new Error('Invalid response from OpenAI assistant');
             }
 
-            return NextResponse.json(result);
+            // Normalize the assistant response to always return
+            // { name: string, nutrients: { ... } }
+            const raw = (result as any).response || {};
+            const nutrientSource = raw.nutrients || raw;
+            const normalizedResponse = {
+                name: typeof raw.name === 'string' ? raw.name : '',
+                nutrients: {
+                    calories: Number(nutrientSource.calories) || 0,
+                    protein: Number(nutrientSource.protein) || 0,
+                    carbohydrates: Number(nutrientSource.carbohydrates) || 0,
+                    fat: Number(nutrientSource.fat) || 0,
+                    fiber: Number(nutrientSource.fiber) || 0,
+                    sugar: Number(nutrientSource.sugar) || 0,
+                    sodium: Number(nutrientSource.sodium) || 0,
+                },
+            };
+
+            return NextResponse.json({
+                ...result,
+                response: normalizedResponse,
+            });
             
         } catch (openaiError: any) {
             console.error('OpenAI API error:', {

--- a/app/pages/authorized_client/camera/page.tsx
+++ b/app/pages/authorized_client/camera/page.tsx
@@ -190,7 +190,10 @@ const CameraTab = () => {
 
       const result = await response.json();
       console.log('Analysis result:', result);
-      setAnalysisResult(result.response);
+      setAnalysisResult({
+        name: result.response.name ?? '',
+        nutrients: result.response.nutrients ?? result.response
+      });
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message || 'An unexpected error occurred');


### PR DESCRIPTION
## Summary
- Normalize OpenAI image analysis API responses into `{ name, nutrients }` shape.
- Update camera page to map backend data into the same normalized structure.
- Ensure analysis result type and usage consume nutrient data from `analysisResult.nutrients.*`.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c47f2356b88330b26a5d56de849794