### PR TITLE
Use hydrated endpoint for social posts

### DIFF
--- a/app/pages/authorized_client/social_platform/page.tsx
+++ b/app/pages/authorized_client/social_platform/page.tsx
@@ -2,7 +2,10 @@ import SocialPlatformClient, { type Post } from "./SocialPlatformClient";
 
 async function getInitialPosts(): Promise<{ posts: Post[]; lastKey: string | null }> {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/social_media?limit=10`, { cache: 'no-store' });
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/social_media/hydrated?limit=10`,
+      { cache: 'no-store' }
+    );
     if (!res.ok) {
       throw new Error('Failed to fetch posts');
     }


### PR DESCRIPTION
## Summary
- Request hydrated social posts on page load
- Simplify client-side post fetching by relying on server data

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5bbad973c8330906b3133ff5f986c