### PR TITLE
feat: cache social posts with react-query

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,7 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from '@/components/auth/AuthProvider'
 
 export function Providers({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient())
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 30, // cacheTime
+      },
+    },
+  }))
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary
- configure global React Query caching with 5m stale time and 30m cache time
- fetch social posts with `useQuery` using stable key and server-provided initial data
- replace local post state with React Query cache and implement lazy loading via `fetchMorePosts`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5c117b5a08330bf40c42c80911b62